### PR TITLE
Use header shim to support local Postgres install

### DIFF
--- a/module.modulemap
+++ b/module.modulemap
@@ -1,5 +1,5 @@
 module libpq {
-    header "/usr/local/include/libpq-fe.h"
+    header "shim.h"
     link "pq"
     export *
 }

--- a/shim.h
+++ b/shim.h
@@ -1,0 +1,9 @@
+#if __has_include("libpq-fe.h")
+#include "libpq-fe.h"
+#elif __has_include("/usr/local/include/libpq-fe.h")
+#include "/usr/local/include/libpq-fe.h"
+#elif __has_include("/Applications/Postgres.app/Contents/Versions/latest/include/libpq-fe.h")
+#include "/Applications/Postgres.app/Contents/Versions/latest/include/libpq-fe.h"
+#elif __has_include("/usr/local/pgsql/include/libpq-fe.h")
+#include "/usr/local/pgsql/include/libpq-fe.h"
+#endif


### PR DESCRIPTION
This branch adds a header "shim" to allow detection and configuration of Postgres header and library files. If the user's paths are configured, `swift build` is sufficient. Otherwise, a specific Postgres can be given by, say:

```
swift build -Xswiftc -I/usr/local/pgsql/include -Xlinker -L/usr/local/pgsql/lib
```